### PR TITLE
Update async book link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The crate is under development as part of a live-coding stream series intended
 for users who are already somewhat familiar with Rust, and who want to see
 something larger and more involved be built. For futures-related stuff, I can
 also highly recommend @aturon's in-progress [Async in Rust
-book](https://aturon.github.io/apr/async-in-rust/chapter.html).
+book](https://rust-lang.github.io/async-book/getting_started/chapter.html).
 
 You can find the recordings of past sessions in [this YouTube
 playlist](https://www.youtube.com/playlist?list=PLqbS7AVVErFgY2faCIYjJZv_RluGkTlKt).

--- a/README.tpl
+++ b/README.tpl
@@ -12,7 +12,7 @@ The crate is under development as part of a live-coding stream series intended
 for users who are already somewhat familiar with Rust, and who want to see
 something larger and more involved be built. For futures-related stuff, I can
 also highly recommend @aturon's in-progress [Async in Rust
-book](https://aturon.github.io/apr/async-in-rust/chapter.html).
+book](https://rust-lang.github.io/async-book/getting_started/chapter.html).
 
 You can find the recordings of past sessions in [this YouTube
 playlist](https://www.youtube.com/playlist?list=PLqbS7AVVErFgY2faCIYjJZv_RluGkTlKt).


### PR DESCRIPTION
The link has moved to an official rust location instead of the main
author's, aturon, account.